### PR TITLE
Install environment security updates

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+data
+private
+tmp
+docs
+chrome

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN chgrp -R woizipass /apps
 USER woizipass
 WORKDIR /apps
 ENV NODE_ENV=production
-RUN npm audit fix
+RUN npm audit fix; exit 0
 RUN npm ci --production
 
 # cleanup

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,9 @@ FROM ubuntu:latest
 RUN apt-get update
 RUN apt-get -y upgrade
 
-#RUN curl -sL https://deb.nodesource.com/setup_current.x | sudo -E bash -
-RUN sudo apt-get install -y nodejs
+RUN apt-get install -y curl
+RUN curl -sL https://deb.nodesource.com/setup_current.x | bash -
+RUN apt-get install -y nodejs
 
 RUN useradd -ms /bin/bash woizipass
 
@@ -30,6 +31,7 @@ RUN chgrp -R woizipass /apps
 USER woizipass
 WORKDIR /apps
 ENV NODE_ENV=production
+RUN npm audit fix
 RUN npm ci --production
 
 # cleanup

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,10 @@
-FROM ubuntu:latest
+FROM ubuntu:20.04
 
+# invalidate the docker cache to restart deployment from here every time
+ADD https://www.google.com /time.now
+
+RUN apt-get update
+RUN apt-get -y dist-upgrade
 RUN apt-get update
 RUN apt-get -y upgrade
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,10 @@
-FROM node:14.4.0
+FROM ubuntu:latest
+
+RUN apt-get update
+RUN apt-get -y upgrade
+
+#RUN curl -sL https://deb.nodesource.com/setup_current.x | sudo -E bash -
+RUN sudo apt-get install -y nodejs
 
 RUN useradd -ms /bin/bash woizipass
 


### PR DESCRIPTION
- Change to ubuntu base image because it hat fewer vulnerabilities than the node base image.
- Run apt-get upgrade to install latest security patches.